### PR TITLE
Fix interpreter errors

### DIFF
--- a/cabal/lib/dependabot/cabal/file_parser.rb
+++ b/cabal/lib/dependabot/cabal/file_parser.rb
@@ -40,11 +40,6 @@ module Dependabot
         end
 
         private
-
-        @PACKAGES_PAYLOAD_REGEX = parse_field_payload_regex("packages").freeze
-        @VERSION_PAYLOAD_REGEX = parse_field_payload_regex("build-depends").freeze
-        @BUILD_DEPENDS_PAYLOAD_REGEX = parse_field_payload_regex("build-depends").freeze
-
         def self.parse_field_payload_regex(field)
           # This regex takes care of indentation sensitivity around fields
           # in cabal.project and *.cabal files.
@@ -68,12 +63,15 @@ module Dependabot
           }
         end
 
+        @@PACKAGES_PAYLOAD_REGEX = parse_field_payload_regex("packages").freeze
+        @@VERSION_PAYLOAD_REGEX = parse_field_payload_regex("build-depends").freeze
+        @@BUILD_DEPENDS_PAYLOAD_REGEX = parse_field_payload_regex("build-depends").freeze
       end
 
       class FileParser < Dependabot::FileParsers::Base
         require "dependabot/file_parsers/base/dependency_set"
 
-        DEPENDENCY_TYPES =
+        @@DEPENDENCY_TYPES =
           %w(dependencies dev-dependencies build-dependencies).freeze
 
         def parse
@@ -293,4 +291,4 @@ module Dependabot
   end
 end
 
-Dependabot::FileParsers.register("cabal", Dependabot::Cabal::FileParser)
+Dependabot::FileParsers.register("cabal", Dependabot::Haskell::Cabal::FileParser)

--- a/cabal/lib/dependabot/cabal/update_checker/file_preparer.rb
+++ b/cabal/lib/dependabot/cabal/update_checker/file_preparer.rb
@@ -67,7 +67,7 @@ module Dependabot
         def replace_version_constraint(content, filename)
           parsed_manifest = TomlRB.parse(content)
 
-          Cabal::FileParser::DEPENDENCY_TYPES.each do |type|
+          Cabal::Haskell::FileParser::DEPENDENCY_TYPES.each do |type|
             dependency_names_for_type(parsed_manifest, type).each do |name|
               req = parsed_manifest.dig(type, name)
 
@@ -88,7 +88,7 @@ module Dependabot
 
         def replace_req_on_target_specific_deps!(parsed_manifest, filename)
           parsed_manifest.fetch("target", {}).each do |target, _|
-            Cabal::FileParser::DEPENDENCY_TYPES.each do |type|
+            Haskell::Cabal::FileParser::DEPENDENCY_TYPES.each do |type|
               dependency_names = dependency_names_for_type_and_target(
                 parsed_manifest,
                 type,

--- a/cabal/spec/dependabot/cabal/file_parser_spec.rb
+++ b/cabal/spec/dependabot/cabal/file_parser_spec.rb
@@ -6,7 +6,7 @@ require "dependabot/dependency_file"
 require "dependabot/source"
 require_common_spec "file_parsers/shared_examples_for_file_parsers"
 
-RSpec.describe Dependabot::Cabal::FileParser do
+RSpec.describe Dependabot::Haskell::Cabal::FileParser do
   it_behaves_like "a dependency file parser"
 
   let(:parser) { described_class.new(dependency_files: files, source: source) }


### PR DESCRIPTION
- static variables in `file_parser.rb` need to be declared with `@@` instead of `@`
- static variables in `file_parser.rb` need to be declared after `parse_field_payload_regex` since they depend on them
- `DEPENDENCY_TYPES` needs to be declared with `@@`
- usages of `Dependabot::Cabal::FileParser` should be `Dependabot::Haskell::Cabal::FileParser`
  Change probably should have gone backwards for consistency, but this was the first thing I tried. Also the interpreter forced me to change the reference in `file_preparer.rb` as well but not too sure if I got that one right. But the interpreter doesn't complain anymore at least.